### PR TITLE
search.py: Filter XML files before downloading and validate API status codes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,3 +13,4 @@ coverage:
       default:
         # basic
         target: 1
+        threshold: 0

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,9 +11,14 @@ coverage:
   status:
     project:
       default:
-        # basic
-        # target: 90
-        # threshold: 1
         # Always succeed
         informational: true
-        if_ci_failed: success #success,error
+        if_ci_failed: success
+        # target: 90
+        # threshold: 1
+    patch:
+      default:
+        target:
+          # Always succeed
+          informational: true
+          if_ci_failed: success

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,24 +1,21 @@
-# Codecov should always pass. Used to show code coverage only
 codecov:
   require_ci_to_pass: false
   notify:
-    wait_for_ci: yes
-
+    require_ci_to_pass: no
+    after_n_builds: 1
 coverage:
-  precision: 2
-  round: down
-  range: 70...95
   status:
     project:
       default:
-        # Always succeed
-        informational: true
-        if_ci_failed: success
-        # target: 90
-        # threshold: 1
+        # Require 1% coverage, i.e., always succeed
+        target: 1
     patch:
       default:
-        target:
-          # Always succeed
-          informational: true
-          if_ci_failed: success
+        target: 0
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+    changes: false
+comment: off
+github_checks:
+    annotations: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,4 +15,5 @@ coverage:
         # target: 90
         # threshold: 1
         # Always succeed
-        if_ci_failed: success #success, failure, error, ignore
+        informational: true
+        if_ci_failed: success #success,error

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,5 +12,7 @@ coverage:
     project:
       default:
         # basic
-        target: 1
-        threshold: 0
+        # target: 90
+        # threshold: 1
+        # Always succeed
+        if_ci_failed: success #success, failure, error, ignore


### PR DESCRIPTION
This PR addresses issue #8 and also adds a check for API status codes in `search.py`