### PR TITLE
Bugfix: stsa.py always downloads VV polarization

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,22 @@
-# Codecov should always pass. Used to show code coverage only
+# Codecov should always pass. Codecov is used for informational purposes only
 codecov:
   require_ci_to_pass: false
   notify:
-    wait_for_ci: yes
-
+    require_ci_to_pass: no
+    after_n_builds: 1
 coverage:
-  precision: 2
-  round: down
-  range: 70...95
   status:
     project:
       default:
-        # basic
+        # Require 1% coverage, i.e., always succeed
         target: 1
+    patch:
+      default:
+        target: 0
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+    changes: false
+comment: off
+github_checks:
+    annotations: false

--- a/stsa/search.py
+++ b/stsa/search.py
@@ -33,7 +33,7 @@ class DownloadXML:
         os.environ['DHUS_USER'] = user
         os.environ['DHUS_PASSWORD'] = password
     
-    def download_xml(self, output_directory: str):
+    def download_xml(self, output_directory: str, polarization: str = 'vv'):
         """
         Download XML metadata from Copernicus Scihub
 
@@ -63,8 +63,8 @@ class DownloadXML:
         for item in range(len(root['feed']['entry'])):
             
             url = root['feed']['entry'][item]['id']
-            
-            if url.endswith(".xml')"):    
+
+            if url.endswith(".xml')") and f'-{polarization}-' in os.path.basename(url):
                 
                 # If it finds an XML file then add /$value to link to the XML file contents
                 url += r'/$value'

--- a/stsa/stsa.py
+++ b/stsa/stsa.py
@@ -116,7 +116,10 @@ class TopsSplitAnalyzer:
                 password=self._api_password,
                 verbose=self._verbose
             )
-            download.download_xml(output_directory=self._download_folder)
+            download.download_xml(
+                output_directory=self._download_folder,
+                polarization=self.polarization
+            )
             self.metadata_file_list = download.xml_paths
             if download.product_is_online is False:
                 return


### PR DESCRIPTION
This addresses a bug where if the user would specify VH when initializing `stsa.py` it would fail because `search.py` would download VV images anyway (#8)