### PR TITLE
stsa.py: Add separate ingestion methods for API and ZIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.prj
 *.dbf
 *.cpg
+.idea/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ CLI access is available if you directly run `stsa.py`. The available flags are:
 | --csv     | Path of output CSV file     |
 | --json    | Path of output JSON file    |
 | --api-user | Copernicus username |
-| --api-password | Copernicus password |
+| --api-password | Copernicus password (Leave empty for secure input) |
 | --api-scene | Sentinel-1 scene ID to download |
 | --api-folder | Folder for downloaded XML files |
 
@@ -54,14 +54,33 @@ python stsa.py --zip S1_image.zip --swaths iw2 iw3 --polar vv --shp out_shp.shp 
 
 ## Python Import
 
-Below is a sample of using `TopsSplitAnalyzer` to create a shapefile and visualize on a webmap. To visualize on a webmap you need to be using Jupyter Notebook.
+Below are code samples of using `TopsSplitAnalyzer`. When loading Sentinel-1 data please choose either API or ZIP 
+method only. 
 
 ```python
-# Create object
+############################################
+# Load data using `load_api` or `load_zip`
+############################################
+
 import stsa
 
 s1 = stsa.TopsSplitAnalyzer(target_subswaths=['iw1', 'iw2', 'iw3'], polarization='vh')
-s1.load_data(zip_path='S1_image.zip')
+
+# METHOD 1: Load using local ZIP file
+s1.load_zip(zip_path='S1_image.zip')
+
+# METHOD 2: Load using Copernicus Scihub API
+s1.load_api(
+    'myusername',
+    'S1A_IW_SLC__1SDV_20210627T043102_20210627T043130_038521_048BB9_DA44',
+    'mypassword'
+)
+```
+```python
+##################################################################
+# Export the data in your preferred format.
+# To visualize on a webmap you need to be using Jupyter Notebook.
+##################################################################
 
 # Write to shapefile
 s1.to_shapefile('data.shp')

--- a/stsa/search.py
+++ b/stsa/search.py
@@ -4,6 +4,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 import xmltodict
 
+
 # Custom errors for download XML
 class DownloadError(Exception):
     pass

--- a/tests/test_stsa.py
+++ b/tests/test_stsa.py
@@ -26,7 +26,7 @@ data2 = os.path.join(TEST_DIR, 'data2', 'S1A_IW_SLC__1SDV_20200929T214701_202009
 def test_TopsSplitAnalyzer_string_subswath():
     
     s1 = TopsSplitAnalyzer(target_subswaths='iw2')
-    s1.load_data(zip_path=data2)
+    s1.load_zip(zip_path=data2)
     out_file = 'test_json.json'
     s1.to_json(out_file)
     
@@ -36,7 +36,7 @@ def test_TopsSplitAnalyzer_string_subswath():
 def test_TopsSplitAnalyzer_use_defaults():
     
     s1 = TopsSplitAnalyzer()
-    s1.load_data(zip_path=data2)
+    s1.load_zip(zip_path=data2)
     expected = 'vv'
     actual = s1.polarization
     assert expected == actual, f'Polarization does not match. Actual is {actual}. Expected is {expected}'
@@ -49,7 +49,7 @@ def test_TopsSplitAnalyzer_use_defaults():
 def test_TopsSplitAnalyzer_string_caps_input():
     "Check input if in all caps"
     s1 = TopsSplitAnalyzer(target_subswaths=['IW1', 'IW2', 'IW3'], polarization='VV')
-    s1.load_data(zip_path=data2)
+    s1.load_zip(zip_path=data2)
     
     expected = 'vv'
     actual = s1.polarization
@@ -69,20 +69,28 @@ def test_TopsSplitAnalyzer_string_caps_input():
 @pytest.mark.xfail
 def test_TopsSplitAnalyzer_xfail_subswath1():
     "Should fail due to improper input for subswaths"
-    s1 = TopsSplitAnalyzer(target_subswaths=['iw1' 'iw2' 'iw3'], polarization='vv')
-    s1.load_data(zip_path=data2)
+    s1 = TopsSplitAnalyzer(target_subswaths=['iw1 iw2 iw3'], polarization='vv')
+    s1.load_zip(zip_path=data2)
     
 @pytest.mark.xfail
 def test_TopsSplitAnalyzer_xfail_subswath2():
     "Should fail due to iw4 not being a valid subswath"
     s1 = TopsSplitAnalyzer(target_subswaths=['iw1', 'iw4'], polarization='vv')
-    s1.load_data(zip_path=data2)
+    s1.load_zip(zip_path=data2)
     
 @pytest.mark.xfail
 def test_TopsSplitAnalyzer_xfail_invalid_polarization():
     "Should fail due to invalid polarization"
     s1 = TopsSplitAnalyzer(image=data2, polarization='HV')
-    s1.load_data(zip_path=data2)
+    s1.load_zip(zip_path=data2)
+
+@pytest.mark.xfail
+def test_non_single_input():
+    "Should fail due to multiple inputs from API and ZIP. Should only be one input."
+
+    cmd = f'python stsa.py --zip {data1} --api-user 123 --api-password 123'.split()
+    subprocess.call(cmd, cwd=STSA_DIR)
+    return
   
 def test_TopsSplitAnalyzer_cli_json():
     "CLI with JSON output"
@@ -160,7 +168,7 @@ def test_TopsSplitAnalyzer_cli_subswaths():
 def test_TopsSplitAnalyzer_data1_all_vv():
     
     s1 = TopsSplitAnalyzer(target_subswaths=['iw1', 'iw2', 'iw3'], polarization='vv')
-    s1.load_data(zip_path=data1)
+    s1.load_zip(zip_path=data1)
     
     ########################################################################
     # Check metadata list. All 6 items should be loaded regardless of user input
@@ -250,7 +258,7 @@ def test_TopsSplitAnalyzer_data1_all_vv():
 def test_TopsSplitAnalyzer_data1_all_vh():
 
     s1 = TopsSplitAnalyzer(target_subswaths=['iw1', 'iw2', 'iw3'], polarization='vh')
-    s1.load_data(zip_path=data1)
+    s1.load_zip(zip_path=data1)
     
     ########################################################################
     # Check metadata list. All 6 items should be loaded regardless of user input
@@ -341,7 +349,7 @@ def test_TopsSplitAnalyzer_data1_all_vh():
 def test_TopsSplitAnalyzer_data2_all_vv():
     
     s1 = TopsSplitAnalyzer(target_subswaths=['iw1', 'iw2', 'iw3'], polarization='vv')
-    s1.load_data(zip_path=data2)
+    s1.load_zip(zip_path=data2)
     
     ########################################################################
     # Check metadata list. All 6 items should be loaded regardless of user input
@@ -433,7 +441,7 @@ def test_TopsSplitAnalyzer_data2_all_vv():
 def test_TopsSplitAnalyzer_data2_all_vh():
     
     s1 = TopsSplitAnalyzer(target_subswaths=['iw1', 'iw2', 'iw3'], polarization='vh')
-    s1.load_data(zip_path=data2)
+    s1.load_zip(zip_path=data2)
     
     ########################################################################
     # Check metadata list. All 6 items should be loaded regardless of user input


### PR DESCRIPTION
## PR Description
This adds methods `load_api` and `load_zip` in `TopsSplitAnalyzer` to reduce confusion and make the ingestion methods more explicit.

Also includes the following:
- Update README.md to reflect changes
- Update tests_stsa.py to reflect changes
- Adds deprecation warning to `load_data` and suggests users use `load_api` or `load_zip` instead

## Linked Issue
Closes #11 